### PR TITLE
feat(products): normalize custom attribute keys to prevent duplicates…

### DIFF
--- a/src/Cleansers/CustomAttributeCleanser.php
+++ b/src/Cleansers/CustomAttributeCleanser.php
@@ -19,7 +19,9 @@ class CustomAttributeCleanser
      */
     public function normalizeName(string $name): string
     {
-        $noAccents = preg_replace('/\p{Mn}/u', '', \Normalizer::normalize($name, \Normalizer::FORM_D));
+        $name       = trim($name);
+        $normalized = \Normalizer::normalize($name, \Normalizer::FORM_D) ?: $name;
+        $noAccents  = preg_replace('/\p{Mn}/u', '', $normalized) ?? $name;
         return str_replace([' ', '-'], '_', mb_strtolower($noAccents));
     }
 
@@ -36,7 +38,11 @@ class CustomAttributeCleanser
     {
         $result = [];
         foreach ($attributes as $name => $value) {
-            $result[$this->normalizeName((string) $name)] = $value;
+            $trimmed = trim((string) $name);
+            if ($trimmed === '') {
+                continue;
+            }
+            $result[$this->normalizeName($trimmed)] = $value;
         }
         return $result;
     }

--- a/src/Endpoints/Products.php
+++ b/src/Endpoints/Products.php
@@ -46,6 +46,7 @@ class Products extends Endpoint
 
     public function create($product)
     {
+        $product  = $this->normalizeCustomAttributeKeys($product);
         $response = $this->post($this->host . '/products', $product);
 
         return $response->getStatusCode() == Endpoint::HTTP_OK || $response->getStatusCode() == Endpoint::HTTP_CREATED;
@@ -53,11 +54,13 @@ class Products extends Endpoint
 
     public function createAsync($product) // returns promise
     {
+        $product = $this->normalizeCustomAttributeKeys($product);
         return $this->postAsync($this->host.'/products', $product);
     }
 
     public function update($sku, $product)
     {
+        $product  = $this->normalizeCustomAttributeKeys($product);
         $response = $this->put($this->host . '/products/' . $this->encode($sku), $product);
 
         if ($response->getStatusCode() == Endpoint::HTTP_OK) {
@@ -71,7 +74,19 @@ class Products extends Endpoint
 
     public function updateAsync($sku, $product) // returns promise
     {
+        $product = $this->normalizeCustomAttributeKeys($product);
         return $this->putAsync($this->host.'/products/'.$this->encode($sku), $product);
+    }
+
+    private function normalizeCustomAttributeKeys(array $product): array
+    {
+        if (empty($product['custom_attributes']) || !is_array($product['custom_attributes'])) {
+            return $product;
+        }
+
+        $product['custom_attributes'] = $this->cleanser->customAttributes->normalizeKeys($product['custom_attributes']);
+
+        return $product;
     }
 
     public function search($search = [], $page = 0, $limit = 100)


### PR DESCRIPTION
## Qué hace este PR

Normaliza automáticamente los nombres de atributos personalizados de producto antes de enviarlos a WoowUp, evitando que se creen definiciones duplicadas cuando el caller pasa nombres con mayúsculas, acentos o guiones.

## Por qué era necesario

WoowUp normaliza los nombres al crear definiciones vía la API de definiciones (`POST /account/product-custom-attributes`), pero **no** al recibir un producto con `custom_attributes` embebidos (`POST /apiv3/products`). En ese segundo caso crea la definición con el nombre exactamente como llega.

Si el caller pasaba `Colecciones`, WoowUp creaba `Colecciones`. Si ya existía `colecciones` (la forma normalizada), terminaban coexistiendo dos definiciones separadas que representan lo mismo.

## Qué se cambió

### `CustomAttributeCleanser` (ya existía en master)

Se alinea con la versión de `woowup-php-client-v2`: se agrega `trim` al inicio de `normalizeName` y se agrega guard de key vacía en `normalizeKeys`.

### `Products::normalizeCustomAttributeKeys()` (nuevo método privado)

Normaliza las keys de `custom_attributes` usando `$this->cleanser->customAttributes->normalizeKeys()` antes de cada llamada a la API. Se aplica en los cuatro métodos de escritura: `create`, `update`, `createAsync`, `updateAsync`. Mismo patrón que `Users::cleanTelephone()`.

## Antes / después

**Antes** — el nombre llegaba a WoowUp exactamente como lo pasó el caller:

```json
POST /apiv3/products
{
  "sku": "ABC123",
  "custom_attributes": {
    "Colecciones": "Verano",
    "TALLE": "M",
    "nombre-complementario": "Remera básica"
  }
}
```

WoowUp creaba definiciones `Colecciones`, `TALLE`, `nombre-complementario` — distintas de las ya existentes `colecciones`, `talle`, `nombre_complementario`.

---

**Después** — `Products` normaliza las keys antes de serializar:

```json
POST /apiv3/products
{
  "sku": "ABC123",
  "custom_attributes": {
    "colecciones": "Verano",
    "talle": "M",
    "nombre_complementario": "Remera básica"
  }
}
```

WoowUp encuentra las definiciones existentes y no crea duplicados.

---

**Ejemplos de normalización:**

| Input caller              | Key en el JSON          |
|---------------------------|-------------------------|
| `Colecciones`             | `colecciones`           |
| `Colección`               | `coleccion`             |
| `TALLE`                   | `talle`                 |
| `Baño`                    | `bano`                  |
| `nombre-complementario`   | `nombre_complementario` |
| `Tipo de Prenda`          | `tipo_de_prenda`        |
| `  Baño  `                | `bano`                  |

---

## Ejemplo real — cuenta Selu (1811, VTEX)

Producto procesado **con este fix activo**. Los atributos vienen de VTEX con nombres como `Tipo de Bombacha`, `Tipo de Tela`, `Colores` — el cliente los normaliza antes de enviarlos. Este es el JSON final que llega a WoowUp:

```json
POST /apiv3/products
{
  "sku": "SEL-001",
  "custom_attributes": {
    "tipo_de_bombacha": ["Less"],
    "tipo_de_tela": ["Microfibra"],
    "colores": ["Azules"]
  }
}
```

Sin el fix, `Tipo de Bombacha` llegaba a WoowUp tal cual y generaba una definición separada de `tipo_de_bombacha`.

```json
{
    "brand": "Selú",
    "description": "Tu nuevo Selú: \nLess de microfibra con puntilla\nColores:\nDescubrí la familia ODILE en blanco, negro, azul y nougat",
    "url": "https://www.selu.com.ar//less-de-tul-y-puntilla-odile-sl7397/p",
    "release_date": "2024-03-15T00:00:00Z",
    "image_url": "http://selulen.vteximg.com.br/arquivos/ids/182692/SL7397_nougat_1.jpg",
    "thumbnail_url": "http://selulen.vteximg.com.br/arquivos/ids/182692/SL7397_nougat_1.jpg",
    "stock": 482,
    "available": true,
    "price": 19900,
    "offer_price": 19900,
    "name": "Less de microfibra y puntilla ODILE",
    "sku": "SL7397",
    "category": [
        { "id": "1", "name": "Ropa Interior", "url": "https://www.selu.com.ar/ropa-interior" },
        { "id": "7", "name": "Bombachas",     "url": "https://www.selu.com.ar/ropa-interior/bombachas" }
    ],
    "custom_attributes": {
        "tipo_de_bombacha": ["Less"],
        "tipo_de_tela": ["Microfibra"],
        "colores": ["Azules"],
        "caracteristicas_de_tela": ["Tela: Microfibra + puntilla\r\nCaracterísticas:\r\nTextil super suave"],
        "composicion": ["80% poliamida - 20% elastano"],
        "iva": ["21"],
        "nombre_complementario": ["Less de microfibibra y puntilla"],
        "colecciones": ["TODOS", "TEST", "Full2025"]
    }
}
```
