### PR TITLE
fix(custom-attributes): support oldName parameter in updateAttributeDefinition for rename operations

### DIFF
--- a/src/Endpoints/CustomAttributes.php
+++ b/src/Endpoints/CustomAttributes.php
@@ -31,9 +31,10 @@ class CustomAttributes extends Endpoint
         return false;
     }
 
-    public function updateAttributeDefinition($data, $entity)
+    public function updateAttributeDefinition($data, $entity, string $oldName = null)
     {
-    	$response = $this->put($this->host . '/account/' . self::ENTITYS[$entity] . '/' . $data->name, $data);
+        $urlName = $oldName ?? $data->name;
+    	$response = $this->put($this->host . '/account/' . self::ENTITYS[$entity] . '/' . $urlName, $data);
 
     	return $response->getStatusCode() == Endpoint::HTTP_OK || $response->getStatusCode() == Endpoint::HTTP_CREATED;
 


### PR DESCRIPTION
Al renombrar un atributo vía `PUT /account/product-custom-attributes/{name}`, la URL debe usar el nombre **actual** del atributo (origen), mientras que el body lleva el nombre nuevo (destino).

El cliente v1 siempre usaba `$data->name` en la URL. Como el handler muta `$data->name` al nombre destino antes de llamar al cliente, la URL quedaba con el nombre nuevo → 404 "attribute not found" → el rename nunca funcionaba.

El bug pasa desapercibido en la mayoría de las cuentas porque los atributos ya tienen nombres canónicos y el path de rename nunca se activa. Solo impacta cuando una cuenta tiene atributos legacy con nombre no normalizado (ej: `Colecciones`) **y** ese atributo es de tipo checkbox/select con muchas opciones acumuladas: al no poder renombrarse, sigue creciendo hasta superar el límite de bytes del schema de WoowUp y bloquear el sync de productos.

## Cambio

Se agrega `$oldName = null` como parámetro opcional, igual que en el cliente v2:

```php
public function updateAttributeDefinition($data, $entity, string $oldName = null)
{
    $urlName = $oldName ?? $data->name;
    $response = $this->put(... . '/' . $urlName, $data);
```

100% backward compatible — callers que no pasan `$oldName` tienen el mismo comportamiento de antes.
