### PR TITLE
refactor(users): mover sanitización a la capa de caché

### DIFF
--- a/src/Endpoints/Users.php
+++ b/src/Endpoints/Users.php
@@ -36,7 +36,6 @@ class Users extends Endpoint
 
     public function update($serviceUid, $user)
     {
-        $user = $this->cleanTelephone($user);
         $response = $this->put($this->host . '/users/' . $this->encode($serviceUid), $user);
 
         return $response->getStatusCode() == Endpoint::HTTP_OK || $response->getStatusCode() == Endpoint::HTTP_CREATED;
@@ -49,7 +48,6 @@ class Users extends Endpoint
 
     public function create($user)
     {
-        $user = $this->cleanTelephone($user);
         $response = $this->post($this->host . '/users', $user);
 
         return $response->getStatusCode() == Endpoint::HTTP_OK || $response->getStatusCode() == Endpoint::HTTP_CREATED;


### PR DESCRIPTION
## Descripción

Se elimina la llamada a `cleanEmail()` y `cleanTelephone()` de `Users.create()` y `Users.update()`.

La sanitización de email y teléfono pasa a ser responsabilidad exclusiva de la capa de caché en connectors (`UsersCache`, `MultiusersCache`, `PurchasesCache`), que la aplica antes de llamar al endpoint. Esto evita el procesamiento duplicado y centraliza la lógica en un único lugar.

## Cambios

- `Users.create()`: se elimina `$user = $this->cleanTelephone($user)`
- `Users.update()`: se elimina `$user = $this->cleanTelephone($user)`