### PR TITLE
feat(email): add TLD suffix correction to email sanitization pipeline

### DIFF
--- a/src/Cleansers/DataCleanser.php
+++ b/src/Cleansers/DataCleanser.php
@@ -46,7 +46,8 @@ class DataCleanser
      */
     public $customAttributes;
 
-    private static ?TldCorrector $globalTldCorrector = null;
+    /** @var TldCorrector|null */
+    private static $globalTldCorrector = null;
 
     /**
      * Configure a TldCorrector that will be used by all DataCleanser instances created afterwards.

--- a/src/Cleansers/DataCleanser.php
+++ b/src/Cleansers/DataCleanser.php
@@ -52,13 +52,15 @@ class DataCleanser
     /**
      * Configure a TldCorrector that will be used by all DataCleanser instances created afterwards.
      * Call once at application startup (e.g. from a feature-flag check in the Pimple provider).
+     * @return void
      */
-    public static function configureGlobalTldCorrector(TldCorrector $corrector): void
+    public static function configureGlobalTldCorrector(TldCorrector $corrector)
     {
         self::$globalTldCorrector = $corrector;
     }
 
-    public function setTldCorrector(TldCorrector $corrector): void
+    /** @return void */
+    public function setTldCorrector(TldCorrector $corrector)
     {
         $this->email = new EmailCleanser($corrector);
     }

--- a/src/Cleansers/DataCleanser.php
+++ b/src/Cleansers/DataCleanser.php
@@ -1,6 +1,8 @@
 <?php
 namespace WoowUp\Cleansers;
 
+use WoowUp\Cleansers\Tld\TldCorrector;
+
 /**
  * DataCleanser
  *
@@ -44,6 +46,22 @@ class DataCleanser
      */
     public $customAttributes;
 
+    private static ?TldCorrector $globalTldCorrector = null;
+
+    /**
+     * Configure a TldCorrector that will be used by all DataCleanser instances created afterwards.
+     * Call once at application startup (e.g. from a feature-flag check in the Pimple provider).
+     */
+    public static function configureGlobalTldCorrector(TldCorrector $corrector): void
+    {
+        self::$globalTldCorrector = $corrector;
+    }
+
+    public function setTldCorrector(TldCorrector $corrector): void
+    {
+        $this->email = new EmailCleanser($corrector);
+    }
+
     /**
      * Initialize all cleansers
      *
@@ -54,7 +72,7 @@ class DataCleanser
         $this->street = new StreetCleanser();
         $this->telephone = new TelephoneCleanser();
         $this->tags = new TagsCleanser();
-        $this->email = new EmailCleanser();
+        $this->email = new EmailCleanser(self::$globalTldCorrector);
         $this->gender = new GenderCleanser();
         $this->birthdate = new BirthdateCleanser();
         $this->customAttributes = new CustomAttributeCleanser();

--- a/src/Cleansers/EmailCleanser.php
+++ b/src/Cleansers/EmailCleanser.php
@@ -3,6 +3,7 @@
 namespace WoowUp\Cleansers;
 
 use WoowUp\Cleansers\Formatters\EmailFormatter;
+use WoowUp\Cleansers\Tld\TldCorrector;
 use WoowUp\Cleansers\Validators\GenericEmailValidator;
 use WoowUp\Cleansers\Validators\LengthValidator;
 use WoowUp\Cleansers\Validators\RepeatedValidator;
@@ -42,8 +43,10 @@ class EmailCleanser
     private $validators;
     private $emailUser;
     private $emailDomain;
+    private ?TldCorrector $tldCorrector;
+    private bool $tldWasCorrected = false;
 
-    public function __construct()
+    public function __construct(?TldCorrector $tldCorrector = null)
     {
         $this->formatter = new EmailFormatter();
         $this->validators = [
@@ -52,8 +55,14 @@ class EmailCleanser
             new SequenceValidator(7, 6, false),
             new GenericEmailValidator(),
         ];
-        $this->emailDomain = null;
-        $this->emailUser   = null;
+        $this->emailDomain    = null;
+        $this->emailUser      = null;
+        $this->tldCorrector   = $tldCorrector;
+    }
+
+    public function wasTldCorrected(): bool
+    {
+        return $this->tldWasCorrected;
     }
 
     /**
@@ -61,6 +70,8 @@ class EmailCleanser
      */
     public function sanitize($email)
     {
+        $this->tldWasCorrected = false;
+
         if (!$this->isValidInput($email)) {
             return false;
         }
@@ -80,9 +91,20 @@ class EmailCleanser
             return false;
         }
 
+        if ($this->tldCorrector !== null && !$this->isGmailDomain()) {
+            $result = $this->tldCorrector->correct($this->emailDomain);
+            if ($result->isIrrecoverable) {
+                return false;
+            }
+            if ($result->wasCorrected) {
+                $this->emailDomain    = $result->correctedDomain;
+                $this->tldWasCorrected = true;
+            }
+        }
+
         return $this->isGmailDomain()
             ? $this->sanitizeGmailEmail()
-            : $this->prettify($email);
+            : $this->prettify($this->emailUser . $this->emailDomain);
     }
 
     /**

--- a/src/Cleansers/EmailCleanser.php
+++ b/src/Cleansers/EmailCleanser.php
@@ -403,8 +403,11 @@ class EmailCleanser
         // Lowercased so provider detection (single/multi-region) and TLD
         // comparisons are case-insensitive — otherwise "YAHOO.CON" never
         // matches "yahoo" or gets its edit distance to "com" computed right.
-        // Trailing dots (e.g. "hotmail.com.") are trimmed so they don't leave
-        // an empty TLD after splitting at the last dot.
-        $this->emailDomain = rtrim(mb_strtolower(substr($email, $atPos)), '.');
+        // Consecutive dots (e.g. "hotmail..con") are collapsed to one, and a
+        // trailing dot (e.g. "hotmail.com.") is trimmed — otherwise either
+        // leaves an empty label, and a trailing one leaves an empty TLD after
+        // splitting at the last dot, making the address irrecoverable.
+        $domain = preg_replace('/\.{2,}/', '.', mb_strtolower(substr($email, $atPos)));
+        $this->emailDomain = rtrim($domain, '.');
     }
 }

--- a/src/Cleansers/EmailCleanser.php
+++ b/src/Cleansers/EmailCleanser.php
@@ -162,8 +162,9 @@ class EmailCleanser
     /**
      * Extracts user and domain parts from an email.
      * Handles multiple @ symbols and Gmail typo detection.
+     * @return void
      */
-    protected function extractEmailParts(string $email): void
+    protected function extractEmailParts(string $email)
     {
         $email = trim($email);
 
@@ -190,12 +191,14 @@ class EmailCleanser
         $this->extractStandardParts($cleanedEmail);
     }
 
-    public function getEmailUser(): ?string
+    /** @return string|null */
+    public function getEmailUser()
     {
         return $this->emailUser;
     }
 
-    public function getEmailDomain(): ?string
+    /** @return string|null */
+    public function getEmailDomain()
     {
         return $this->emailDomain;
     }
@@ -277,7 +280,8 @@ class EmailCleanser
         return $email;
     }
 
-    private function resetEmailParts(): void
+    /** @return void */
+    private function resetEmailParts()
     {
         $this->emailUser = null;
         $this->emailDomain = null;
@@ -389,8 +393,9 @@ class EmailCleanser
 
     /**
      * Extracts standard email parts (non-Gmail).
+     * @return void
      */
-    private function extractStandardParts(string $email): void
+    private function extractStandardParts(string $email)
     {
         $atPos = strpos($email, '@');
 

--- a/src/Cleansers/EmailCleanser.php
+++ b/src/Cleansers/EmailCleanser.php
@@ -48,7 +48,7 @@ class EmailCleanser
     /** @var bool */
     private $tldWasCorrected = false;
 
-    public function __construct(?TldCorrector $tldCorrector = null)
+    public function __construct(TldCorrector $tldCorrector = null)
     {
         $this->formatter = new EmailFormatter();
         $this->validators = [

--- a/src/Cleansers/EmailCleanser.php
+++ b/src/Cleansers/EmailCleanser.php
@@ -408,11 +408,18 @@ class EmailCleanser
         // Lowercased so provider detection (single/multi-region) and TLD
         // comparisons are case-insensitive — otherwise "YAHOO.CON" never
         // matches "yahoo" or gets its edit distance to "com" computed right.
+        $domain = mb_strtolower(substr($email, $atPos));
+        // Comma or whitespace standing in for the dot separator (e.g.
+        // "gmail,com", "copaair, com") is never valid inside a real domain,
+        // unlike a hyphen — which legitimately appears in real domains
+        // ("mi-empresa.com.ar") and is deliberately left untouched here, since
+        // blindly dotting it could turn one real domain into a different one.
+        $domain = preg_replace('/[,\s]+/', '.', $domain);
         // Consecutive dots (e.g. "hotmail..con") are collapsed to one, and a
         // trailing dot (e.g. "hotmail.com.") is trimmed — otherwise either
         // leaves an empty label, and a trailing one leaves an empty TLD after
         // splitting at the last dot, making the address irrecoverable.
-        $domain = preg_replace('/\.{2,}/', '.', mb_strtolower(substr($email, $atPos)));
+        $domain = preg_replace('/\.{2,}/', '.', $domain);
         $this->emailDomain = rtrim($domain, '.');
     }
 }

--- a/src/Cleansers/EmailCleanser.php
+++ b/src/Cleansers/EmailCleanser.php
@@ -316,26 +316,28 @@ class EmailCleanser
     }
 
     /**
-     * Checks if the domain part contains mixed domains (Gmail + another provider).
+     * Checks if the domain part contains mixed domains (Gmail + another provider),
+     * e.g. "gmailhotmail.com". Only counts a known domain found outside the matched
+     * Gmail-variant substring — otherwise a plain Gmail typo like "gmaol.com" would
+     * false-positive on "aol" (a substring of "gmaol") and get rejected instead of
+     * corrected to "@gmail.com".
      */
     private function hasMixedDomains(string $domainPart): bool
     {
-        $hasGmail = $this->containsGmailDomain($domainPart);
+        $dp = mb_strtolower($domainPart);
 
-        if (!$hasGmail) {
-            return false;
-        }
-
-        return $this->containsOtherKnownDomain($domainPart);
-    }
-
-    private function containsGmailDomain(string $domainPart): bool
-    {
         foreach (self::GMAIL_DOMAINS as $gmailDomain) {
-            if (strpos($domainPart, $gmailDomain) !== false) {
+            $pos = strpos($dp, $gmailDomain);
+            if ($pos === false) {
+                continue;
+            }
+
+            $rest = substr($dp, 0, $pos) . substr($dp, $pos + strlen($gmailDomain));
+            if ($this->containsOtherKnownDomain($rest)) {
                 return true;
             }
         }
+
         return false;
     }
 
@@ -398,6 +400,11 @@ class EmailCleanser
         }
 
         $this->emailUser = substr($email, 0, $atPos);
-        $this->emailDomain = substr($email, $atPos);
+        // Lowercased so provider detection (single/multi-region) and TLD
+        // comparisons are case-insensitive — otherwise "YAHOO.CON" never
+        // matches "yahoo" or gets its edit distance to "com" computed right.
+        // Trailing dots (e.g. "hotmail.com.") are trimmed so they don't leave
+        // an empty TLD after splitting at the last dot.
+        $this->emailDomain = rtrim(mb_strtolower(substr($email, $atPos)), '.');
     }
 }

--- a/src/Cleansers/EmailCleanser.php
+++ b/src/Cleansers/EmailCleanser.php
@@ -104,9 +104,16 @@ class EmailCleanser
             }
         }
 
-        return $this->isGmailDomain()
-            ? $this->sanitizeGmailEmail()
-            : $this->prettify($this->emailUser . $this->emailDomain);
+        if ($this->isGmailDomain()) {
+            return $this->sanitizeGmailEmail();
+        }
+
+        // Pre-TLD-correction behavior returned the raw input; kept as-is when the
+        // feature is off so disabling FEATURE_TLD_CORRECTION restores byte-identical
+        // legacy output, not just "no TLD correction applied".
+        return $this->tldCorrector !== null
+            ? $this->prettify($this->emailUser . $this->emailDomain)
+            : $this->prettify($email);
     }
 
     /**
@@ -320,14 +327,20 @@ class EmailCleanser
     }
 
     /**
-     * Checks if the domain part contains mixed domains (Gmail + another provider),
-     * e.g. "gmailhotmail.com". Only counts a known domain found outside the matched
-     * Gmail-variant substring — otherwise a plain Gmail typo like "gmaol.com" would
-     * false-positive on "aol" (a substring of "gmaol") and get rejected instead of
-     * corrected to "@gmail.com".
+     * Checks if the domain part contains mixed domains (Gmail + another provider).
+     *
+     * With TLD correction enabled, a known domain only counts if found outside the
+     * matched Gmail-variant substring — otherwise a plain Gmail typo like "gmaol.com"
+     * would false-positive on "aol" (a substring of "gmaol") and get rejected instead
+     * of corrected to "@gmail.com". Kept behind the flag so disabling
+     * FEATURE_TLD_CORRECTION restores the exact legacy detection.
      */
     private function hasMixedDomains(string $domainPart): bool
     {
+        if ($this->tldCorrector === null) {
+            return $this->containsGmailDomain($domainPart) && $this->containsOtherKnownDomain($domainPart);
+        }
+
         $dp = mb_strtolower($domainPart);
 
         foreach (self::GMAIL_DOMAINS as $gmailDomain) {
@@ -342,6 +355,16 @@ class EmailCleanser
             }
         }
 
+        return false;
+    }
+
+    private function containsGmailDomain(string $domainPart): bool
+    {
+        foreach (self::GMAIL_DOMAINS as $gmailDomain) {
+            if (strpos($domainPart, $gmailDomain) !== false) {
+                return true;
+            }
+        }
         return false;
     }
 
@@ -405,6 +428,14 @@ class EmailCleanser
         }
 
         $this->emailUser = substr($email, 0, $atPos);
+
+        // Legacy behavior: no domain normalization, kept so disabling
+        // FEATURE_TLD_CORRECTION restores the exact pre-TLD-correction extraction.
+        if ($this->tldCorrector === null) {
+            $this->emailDomain = substr($email, $atPos);
+            return;
+        }
+
         // Lowercased so provider detection (single/multi-region) and TLD
         // comparisons are case-insensitive — otherwise "YAHOO.CON" never
         // matches "yahoo" or gets its edit distance to "com" computed right.

--- a/src/Cleansers/EmailCleanser.php
+++ b/src/Cleansers/EmailCleanser.php
@@ -43,8 +43,10 @@ class EmailCleanser
     private $validators;
     private $emailUser;
     private $emailDomain;
-    private ?TldCorrector $tldCorrector;
-    private bool $tldWasCorrected = false;
+    /** @var TldCorrector|null */
+    private $tldCorrector;
+    /** @var bool */
+    private $tldWasCorrected = false;
 
     public function __construct(?TldCorrector $tldCorrector = null)
     {

--- a/src/Cleansers/Tld/IanaTldProvider.php
+++ b/src/Cleansers/Tld/IanaTldProvider.php
@@ -13,9 +13,12 @@ class IanaTldProvider
         'jp', 'cn', 'in', 'kr', 'io', 'lat', 'tv', 'info', 'biz', 'name', 'mobi', 'tel', 'pro',
     ];
 
-    private string $cacheFile;
-    private int    $ttl;
-    private ?array $tlds = null;
+    /** @var string */
+    private $cacheFile;
+    /** @var int */
+    private $ttl;
+    /** @var array|null */
+    private $tlds = null;
 
     public function __construct(string $cacheFile = '/tmp/iana_tlds.cache', int $ttl = 604800)
     {
@@ -73,7 +76,9 @@ class IanaTldProvider
             return null;
         }
 
-        @file_put_contents($this->cacheFile, json_encode($tlds));
+        $tmp = $this->cacheFile . '.tmp.' . getmypid();
+        @file_put_contents($tmp, json_encode($tlds), LOCK_EX);
+        @rename($tmp, $this->cacheFile);
         return $tlds;
     }
 

--- a/src/Cleansers/Tld/IanaTldProvider.php
+++ b/src/Cleansers/Tld/IanaTldProvider.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace WoowUp\Cleansers\Tld;
+
+class IanaTldProvider
+{
+    const IANA_URL = 'https://data.iana.org/TLD/tlds-alpha-by-domain.txt';
+
+    const FALLBACK_TLDS = [
+        'com', 'net', 'org', 'edu', 'gov', 'mil', 'int',
+        'ar', 'es', 'br', 'mx', 'co', 'cl', 'pe', 'bo', 'uy', 'py', 'ec', 've', 'cr', 'pa', 'gt', 'hn', 'sv', 'ni', 'do', 'cu', 'pr',
+        'us', 'uk', 'ca', 'au', 'de', 'fr', 'it', 'pt', 'nl', 'be', 'ch', 'at', 'se', 'no', 'dk', 'fi', 'pl', 'cz', 'ru',
+        'jp', 'cn', 'in', 'kr', 'io', 'lat', 'tv', 'info', 'biz', 'name', 'mobi', 'tel', 'pro',
+    ];
+
+    private string $cacheFile;
+    private int    $ttl;
+    private ?array $tlds = null;
+
+    public function __construct(string $cacheFile = '/tmp/iana_tlds.cache', int $ttl = 604800)
+    {
+        $this->cacheFile = $cacheFile;
+        $this->ttl       = $ttl;
+    }
+
+    public function isValid(string $tld): bool
+    {
+        return in_array(strtolower($tld), $this->getAll(), true);
+    }
+
+    public function getAll(): array
+    {
+        if ($this->tlds !== null) {
+            return $this->tlds;
+        }
+
+        $this->tlds = $this->loadFromCache() ?? $this->fetchAndCache() ?? self::FALLBACK_TLDS;
+        return $this->tlds;
+    }
+
+    public function refresh(): void
+    {
+        $this->tlds = null;
+        if (file_exists($this->cacheFile)) {
+            unlink($this->cacheFile);
+        }
+        $this->getAll();
+    }
+
+    private function loadFromCache(): ?array
+    {
+        if (!file_exists($this->cacheFile)) {
+            return null;
+        }
+
+        if ((time() - filemtime($this->cacheFile)) > $this->ttl) {
+            return null;
+        }
+
+        $data = json_decode(file_get_contents($this->cacheFile), true);
+        return is_array($data) ? $data : null;
+    }
+
+    private function fetchAndCache(): ?array
+    {
+        $raw = @file_get_contents(self::IANA_URL);
+        if ($raw === false) {
+            return null;
+        }
+
+        $tlds = $this->parse($raw);
+        if (empty($tlds)) {
+            return null;
+        }
+
+        @file_put_contents($this->cacheFile, json_encode($tlds));
+        return $tlds;
+    }
+
+    private function parse(string $raw): array
+    {
+        $tlds = [];
+        foreach (explode("\n", $raw) as $line) {
+            $line = trim($line);
+            if ($line === '' || $line[0] === '#') {
+                continue;
+            }
+            // Skip IDN entries (xn--)
+            if (stripos($line, 'xn--') === 0) {
+                continue;
+            }
+            $tlds[] = strtolower($line);
+        }
+        return $tlds;
+    }
+}

--- a/src/Cleansers/Tld/IanaTldProvider.php
+++ b/src/Cleansers/Tld/IanaTldProvider.php
@@ -43,7 +43,8 @@ class IanaTldProvider
         return $this->tlds;
     }
 
-    public function refresh(): void
+    /** @return void */
+    public function refresh()
     {
         $this->tlds = null;
         if (file_exists($this->cacheFile)) {
@@ -52,7 +53,8 @@ class IanaTldProvider
         $this->getAll();
     }
 
-    private function loadFromCache(): ?array
+    /** @return array|null */
+    private function loadFromCache()
     {
         if (!file_exists($this->cacheFile)) {
             return null;
@@ -65,7 +67,8 @@ class IanaTldProvider
         return $this->readCacheFile();
     }
 
-    private function readCacheFile(): ?array
+    /** @return array|null */
+    private function readCacheFile()
     {
         if (!file_exists($this->cacheFile)) {
             return null;
@@ -75,7 +78,8 @@ class IanaTldProvider
         return is_array($data) ? $data : null;
     }
 
-    private function fetchAndCache(): ?array
+    /** @return array|null */
+    private function fetchAndCache()
     {
         $raw = @file_get_contents(self::IANA_URL);
         if ($raw === false) {

--- a/src/Cleansers/Tld/IanaTldProvider.php
+++ b/src/Cleansers/Tld/IanaTldProvider.php
@@ -37,7 +37,9 @@ class IanaTldProvider
             return $this->tlds;
         }
 
-        $this->tlds = $this->loadFromCache() ?? $this->fetchAndCache() ?? self::FALLBACK_TLDS;
+        // Stale-if-error: an expired cache from a past successful fetch is still
+        // far more accurate than the hardcoded fallback list.
+        $this->tlds = $this->loadFromCache() ?? $this->fetchAndCache() ?? $this->readCacheFile() ?? self::FALLBACK_TLDS;
         return $this->tlds;
     }
 
@@ -57,6 +59,15 @@ class IanaTldProvider
         }
 
         if ((time() - filemtime($this->cacheFile)) > $this->ttl) {
+            return null;
+        }
+
+        return $this->readCacheFile();
+    }
+
+    private function readCacheFile(): ?array
+    {
+        if (!file_exists($this->cacheFile)) {
             return null;
         }
 

--- a/src/Cleansers/Tld/TldCorrectionResult.php
+++ b/src/Cleansers/Tld/TldCorrectionResult.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WoowUp\Cleansers\Tld;
+
+class TldCorrectionResult
+{
+    public bool $wasCorrected;
+    public bool $isIrrecoverable;
+    public ?string $correctedDomain;
+
+    private function __construct(bool $wasCorrected, bool $isIrrecoverable, ?string $correctedDomain)
+    {
+        $this->wasCorrected     = $wasCorrected;
+        $this->isIrrecoverable  = $isIrrecoverable;
+        $this->correctedDomain  = $correctedDomain;
+    }
+
+    public static function unchanged(string $domain): self
+    {
+        return new self(false, false, $domain);
+    }
+
+    public static function corrected(string $domain): self
+    {
+        return new self(true, false, $domain);
+    }
+
+    public static function irrecoverable(): self
+    {
+        return new self(false, true, null);
+    }
+}

--- a/src/Cleansers/Tld/TldCorrectionResult.php
+++ b/src/Cleansers/Tld/TldCorrectionResult.php
@@ -4,11 +4,14 @@ namespace WoowUp\Cleansers\Tld;
 
 class TldCorrectionResult
 {
-    public bool $wasCorrected;
-    public bool $isIrrecoverable;
-    public ?string $correctedDomain;
+    /** @var bool */
+    public $wasCorrected;
+    /** @var bool */
+    public $isIrrecoverable;
+    /** @var string|null */
+    public $correctedDomain;
 
-    private function __construct(bool $wasCorrected, bool $isIrrecoverable, ?string $correctedDomain)
+    private function __construct($wasCorrected, $isIrrecoverable, $correctedDomain)
     {
         $this->wasCorrected     = $wasCorrected;
         $this->isIrrecoverable  = $isIrrecoverable;

--- a/src/Cleansers/Tld/TldCorrector.php
+++ b/src/Cleansers/Tld/TldCorrector.php
@@ -113,7 +113,12 @@ class TldCorrector
     private function correctMultiRegionDomain(string $name, string $tld): TldCorrectionResult
     {
         if ($this->iana->isValid($tld)) {
-            if (in_array($tld, $this->denylist, true)) {
+            // Denylist only applies to a bare suffix (yahoo.co), never to a legitimate
+            // two-level regional suffix (yahoo.com.co) — otherwise "yahoo.com.co" would
+            // be corrected to "yahoo.com.com".
+            $firstLabel = explode('.', $name)[0];
+            $isBare = $name === $firstLabel;
+            if ($isBare && in_array($tld, $this->denylist, true)) {
                 return TldCorrectionResult::corrected('@' . $name . '.com');
             }
             $this->logNewSuffix($name, $tld);

--- a/src/Cleansers/Tld/TldCorrector.php
+++ b/src/Cleansers/Tld/TldCorrector.php
@@ -82,6 +82,15 @@ class TldCorrector
         list($name, $tld) = $this->splitAtLastDot($domain);
 
         if ($tld === '') {
+            // No dot at all (e.g. "hotmail", "hotmailcom", "outlookcom") — if the
+            // whole domain is a known provider, possibly with "com" stuck on with
+            // no separator, rebuild it as the canonical "provider.com" instead of
+            // rejecting outright. Only exact known-provider matches; a dotless
+            // custom domain has no safe way to guess a TLD, stays irrecoverable.
+            $reconstructed = $this->reconstructKnownProvider($domain);
+            if ($reconstructed !== null) {
+                return TldCorrectionResult::corrected('@' . $reconstructed);
+            }
             return TldCorrectionResult::irrecoverable();
         }
 
@@ -116,6 +125,22 @@ class TldCorrector
         }
 
         return 'custom';
+    }
+
+    /** @return string|null */
+    private function reconstructKnownProvider(string $domain)
+    {
+        foreach ($this->singleDomainProviders as $provider => $canonicalTld) {
+            if ($domain === $provider || $domain === $provider . $canonicalTld) {
+                return $provider . '.' . $canonicalTld;
+            }
+        }
+        foreach ($this->multiRegionProviders as $provider) {
+            if ($domain === $provider || $domain === $provider . 'com') {
+                return $provider . '.com';
+            }
+        }
+        return null;
     }
 
     // -------------------------------------------------------------------------

--- a/src/Cleansers/Tld/TldCorrector.php
+++ b/src/Cleansers/Tld/TldCorrector.php
@@ -122,25 +122,38 @@ class TldCorrector
 
     private function correctMultiRegionDomain(string $name, string $tld): TldCorrectionResult
     {
+        // Resolve to a single TLD candidate first — either the original (if
+        // already valid) or the edit-distance/prefix correction — then apply
+        // the denylist check once, uniformly, regardless of which path got us
+        // there. Otherwise a candidate produced by correctInvalidTld (e.g.
+        // "hotmail.c" -> "co") never gets re-checked against the denylist and
+        // a known provider ends up on a TLD it should never keep (hotmail.co).
+        $wasCorrected = false;
         if ($this->iana->isValid($tld)) {
-            // Denylist only applies to a bare suffix (yahoo.co), never to a legitimate
-            // two-level regional suffix (yahoo.com.co) — otherwise "yahoo.com.co" would
-            // be corrected to "yahoo.com.com".
-            $firstLabel = explode('.', $name)[0];
-            $isBare = $name === $firstLabel;
-            if ($isBare && in_array($tld, $this->denylist, true)) {
-                return TldCorrectionResult::corrected('@' . $name . '.com');
+            $candidate = $tld;
+        } else {
+            $candidate = $this->correctInvalidTld($name, $tld);
+            if ($candidate === null) {
+                return TldCorrectionResult::irrecoverable();
             }
+            $wasCorrected = true;
+        }
+
+        // Denylist only applies to a bare suffix (yahoo.co), never to a legitimate
+        // two-level regional suffix (yahoo.com.co) — otherwise "yahoo.com.co" would
+        // be corrected to "yahoo.com.com".
+        $firstLabel = explode('.', $name)[0];
+        $isBare = $name === $firstLabel;
+        if ($isBare && in_array($candidate, $this->denylist, true)) {
+            return TldCorrectionResult::corrected('@' . $name . '.com');
+        }
+
+        if (!$wasCorrected) {
             $this->logNewSuffix($name, $tld);
             return TldCorrectionResult::unchanged('@' . $name . '.' . $tld);
         }
 
-        $corrected = $this->correctInvalidTld($name, $tld);
-        if ($corrected === null) {
-            return TldCorrectionResult::irrecoverable();
-        }
-
-        return TldCorrectionResult::corrected('@' . $name . '.' . $corrected);
+        return TldCorrectionResult::corrected('@' . $name . '.' . $candidate);
     }
 
     private function correctCustomDomain(string $name, string $tld): TldCorrectionResult

--- a/src/Cleansers/Tld/TldCorrector.php
+++ b/src/Cleansers/Tld/TldCorrector.php
@@ -166,7 +166,8 @@ class TldCorrector
      * The order edit-distance → prefix is critical: without it, "con" would match prefix "co"
      * instead of being corrected to "com" via edit distance 1.
      */
-    private function correctInvalidTld(string $name, string $tld): ?string
+    /** @return string|null */
+    private function correctInvalidTld(string $name, string $tld)
     {
         // Pre-process IDN punycode: xn--com-9ma → extract leading alpha root → "com".
         // This handles cases where the TLD is a punycode-encoded form of a common TLD.
@@ -200,7 +201,8 @@ class TldCorrector
         return $this->findByPrefix($name, $tld);
     }
 
-    private function findByEditDistance(string $tld, int $maxDistance, ?array $candidates = null): ?string
+    /** @return string|null */
+    private function findByEditDistance(string $tld, int $maxDistance, array $candidates = null)
     {
         foreach ($candidates ?? $this->targetTlds as $target) {
             if (levenshtein($tld, $target) <= $maxDistance) {
@@ -210,7 +212,8 @@ class TldCorrector
         return null;
     }
 
-    private function findByPrefix(string $name, string $tld): ?string
+    /** @return string|null */
+    private function findByPrefix(string $name, string $tld)
     {
         // Try longest matching prefix first to prefer "com.ar" over "com" for "comar".
         $candidates = $this->targetTlds;
@@ -259,7 +262,8 @@ class TldCorrector
         return [substr($domain, 0, $pos), substr($domain, $pos + 1)];
     }
 
-    private function logNewSuffix(string $providerName, string $tld): void
+    /** @return void */
+    private function logNewSuffix(string $providerName, string $tld)
     {
         if ($this->newSuffixLog === null) {
             return;

--- a/src/Cleansers/Tld/TldCorrector.php
+++ b/src/Cleansers/Tld/TldCorrector.php
@@ -258,11 +258,45 @@ class TldCorrector
     private function findByEditDistance(string $tld, int $maxDistance, array $candidates = null)
     {
         foreach ($candidates ?? $this->targetTlds as $target) {
-            if (levenshtein($tld, $target) <= $maxDistance) {
+            if (self::damerauLevenshtein($tld, $target) <= $maxDistance) {
                 return $target;
             }
         }
         return null;
+    }
+
+    // Optimal String Alignment distance: like PHP's native levenshtein()
+    // (insert/delete/substitute), plus an adjacent-transposition op at cost 1
+    // — so "ocm" is distance 1 from "com" instead of 2, catching swapped-letter
+    // typos like hotmail.ocm without widening the match to unrelated TLDs. No
+    // pair in DEFAULT_TARGET_TLDS/DEFAULT_COUNTRY_CODE_PARTNERS transposes into
+    // another one of those targets, so this only ever resolves a typo back to
+    // the same TLD it came from.
+    private static function damerauLevenshtein(string $s1, string $s2): int
+    {
+        $len1 = strlen($s1);
+        $len2 = strlen($s2);
+        $d    = [];
+        for ($i = 0; $i <= $len1; $i++) {
+            $d[$i][0] = $i;
+        }
+        for ($j = 0; $j <= $len2; $j++) {
+            $d[0][$j] = $j;
+        }
+        for ($i = 1; $i <= $len1; $i++) {
+            for ($j = 1; $j <= $len2; $j++) {
+                $cost      = $s1[$i - 1] === $s2[$j - 1] ? 0 : 1;
+                $d[$i][$j] = min(
+                    $d[$i - 1][$j] + 1,
+                    $d[$i][$j - 1] + 1,
+                    $d[$i - 1][$j - 1] + $cost
+                );
+                if ($i > 1 && $j > 1 && $s1[$i - 1] === $s2[$j - 2] && $s1[$i - 2] === $s2[$j - 1]) {
+                    $d[$i][$j] = min($d[$i][$j], $d[$i - 2][$j - 2] + 1);
+                }
+            }
+        }
+        return $d[$len1][$len2];
     }
 
     /** @return string|null */

--- a/src/Cleansers/Tld/TldCorrector.php
+++ b/src/Cleansers/Tld/TldCorrector.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace WoowUp\Cleansers\Tld;
+
+class TldCorrector
+{
+    // Providers where only one canonical TLD is valid regardless of what IANA says.
+    const DEFAULT_SINGLE_DOMAIN_PROVIDERS = [
+        'gmail'  => 'com',
+        'icloud' => 'com',
+    ];
+
+    // Providers that operate in multiple regions; IANA is the default but a short denylist applies.
+    const DEFAULT_MULTI_REGION_PROVIDERS = [
+        'hotmail', 'outlook', 'yahoo', 'live', 'msn', 'aol', 'proton', 'protonmail', 'zoho',
+    ];
+
+    // Valid IANA TLDs that known providers never use standalone (e.g. yahoo.co is not real).
+    const DEFAULT_DENYLIST = ['co'];
+
+    // Ordered list of target TLDs for edit-distance and prefix corrections.
+    const DEFAULT_TARGET_TLDS = [
+        'com', 'ar', 'es', 'net', 'org', 'br', 'io', 'co', 'lat', 'mx', 'cl', 'pe', 'uy', 'edu', 'gov',
+    ];
+
+    private IanaTldProvider $iana;
+    private array $singleDomainProviders;
+    private array $multiRegionProviders;
+    private array $denylist;
+    private array $targetTlds;
+    private ?string $newSuffixLog;
+
+    public function __construct(IanaTldProvider $iana, array $config = [])
+    {
+        $this->iana                  = $iana;
+        $this->singleDomainProviders = $config['single_domain_providers'] ?? self::DEFAULT_SINGLE_DOMAIN_PROVIDERS;
+        $this->multiRegionProviders  = $config['multi_region_providers']  ?? self::DEFAULT_MULTI_REGION_PROVIDERS;
+        $this->denylist              = $config['denylist']                ?? self::DEFAULT_DENYLIST;
+        $this->targetTlds            = $config['target_tlds']             ?? self::DEFAULT_TARGET_TLDS;
+        $this->newSuffixLog          = $config['new_suffix_log']          ?? null;
+    }
+
+    /**
+     * Receives the domain portion as stored in EmailCleanser (e.g. "@hotmail.comm").
+     * Returns a TldCorrectionResult with the corrected "@domain.tld" or irrecoverable flag.
+     */
+    public function correct(string $emailDomain): TldCorrectionResult
+    {
+        // Strip leading "@" for processing, restore it in the result.
+        $domain = ltrim($emailDomain, '@');
+        [$name, $tld] = $this->splitAtLastDot($domain);
+
+        if ($tld === '') {
+            return TldCorrectionResult::irrecoverable();
+        }
+
+        $providerType = $this->detectProviderType($name);
+
+        if ($providerType === 'single') {
+            return $this->correctSingleDomain($name, $tld);
+        }
+
+        if ($providerType === 'multi_region') {
+            return $this->correctMultiRegionDomain($name, $tld);
+        }
+
+        return $this->correctCustomDomain($name, $tld);
+    }
+
+    // -------------------------------------------------------------------------
+    // Provider type detection
+    // -------------------------------------------------------------------------
+
+    private function detectProviderType(string $name): string
+    {
+        // Name may be "yahoo.com" for "yahoo.com.arr" — extract the first label.
+        $firstLabel = explode('.', $name)[0];
+
+        if (isset($this->singleDomainProviders[$firstLabel])) {
+            return 'single';
+        }
+
+        if (in_array($firstLabel, $this->multiRegionProviders, true)) {
+            return 'multi_region';
+        }
+
+        return 'custom';
+    }
+
+    // -------------------------------------------------------------------------
+    // Correction strategies
+    // -------------------------------------------------------------------------
+
+    private function correctSingleDomain(string $name, string $tld): TldCorrectionResult
+    {
+        $firstLabel    = explode('.', $name)[0];
+        $canonicalTld  = $this->singleDomainProviders[$firstLabel];
+        $canonicalFull = $firstLabel . '.' . $canonicalTld;
+
+        if ($tld === $canonicalTld && $name === $firstLabel) {
+            return TldCorrectionResult::unchanged('@' . $name . '.' . $tld);
+        }
+
+        return TldCorrectionResult::corrected('@' . $canonicalFull);
+    }
+
+    private function correctMultiRegionDomain(string $name, string $tld): TldCorrectionResult
+    {
+        if ($this->iana->isValid($tld)) {
+            if (in_array($tld, $this->denylist, true)) {
+                return TldCorrectionResult::corrected('@' . $name . '.com');
+            }
+            $this->logNewSuffix($name, $tld);
+            return TldCorrectionResult::unchanged('@' . $name . '.' . $tld);
+        }
+
+        $corrected = $this->correctInvalidTld($name, $tld);
+        if ($corrected === null) {
+            return TldCorrectionResult::irrecoverable();
+        }
+
+        return TldCorrectionResult::corrected('@' . $name . '.' . $corrected);
+    }
+
+    private function correctCustomDomain(string $name, string $tld): TldCorrectionResult
+    {
+        if ($this->iana->isValid($tld)) {
+            return TldCorrectionResult::unchanged('@' . $name . '.' . $tld);
+        }
+
+        $corrected = $this->correctInvalidTld($name, $tld);
+        if ($corrected === null) {
+            return TldCorrectionResult::irrecoverable();
+        }
+
+        return TldCorrectionResult::corrected('@' . $name . '.' . $corrected);
+    }
+
+    // -------------------------------------------------------------------------
+    // Core correction: edit distance → prefix (order is critical)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the corrected TLD string (may be compound like "com.ar") or null if irrecoverable.
+     * The order edit-distance → prefix is critical: without it, "con" would match prefix "co"
+     * instead of being corrected to "com" via edit distance 1.
+     */
+    private function correctInvalidTld(string $name, string $tld): ?string
+    {
+        // Pre-process IDN punycode: xn--com-9ma → extract leading alpha root → "com".
+        // This handles cases where the TLD is a punycode-encoded form of a common TLD.
+        if (strpos($tld, 'xn--') === 0) {
+            $stripped = substr($tld, 4);
+            preg_match('/^[a-z]+/', $stripped, $m);
+            if (!empty($m[0]) && $this->iana->isValid($m[0])) {
+                return $m[0];
+            }
+            $tld = $stripped;
+        }
+
+        // Step 1: edit distance = 1 against target TLDs (ordered by frequency).
+        $editMatch = $this->findByEditDistance($tld, 1);
+        if ($editMatch !== null) {
+            return $editMatch;
+        }
+
+        // Step 2: prefix — find the longest target TLD that is a prefix of the invalid label.
+        return $this->findByPrefix($name, $tld);
+    }
+
+    private function findByEditDistance(string $tld, int $maxDistance): ?string
+    {
+        foreach ($this->targetTlds as $target) {
+            if (levenshtein($tld, $target) <= $maxDistance) {
+                return $target;
+            }
+        }
+        return null;
+    }
+
+    private function findByPrefix(string $name, string $tld): ?string
+    {
+        // Try longest matching prefix first to prefer "com.ar" over "com" for "comar".
+        $candidates = $this->targetTlds;
+        usort($candidates, fn($a, $b) => strlen($b) - strlen($a));
+
+        foreach ($candidates as $target) {
+            if (strpos($tld, $target) === 0) {
+                $tail = substr($tld, strlen($target));
+
+                if ($tail === '') {
+                    return $target;
+                }
+
+                // If tail is a valid 2-letter ccTLD and doesn't duplicate the last label of $name,
+                // insert it as a second-level label.
+                if (strlen($tail) === 2 && $this->iana->isValid($tail)) {
+                    $nameParts = explode('.', $name);
+                    $lastNameLabel = end($nameParts);
+                    if ($lastNameLabel !== $tail) {
+                        return $target . '.' . $tail;
+                    }
+                }
+
+                // Tail is noise — return only the prefix.
+                return $target;
+            }
+        }
+
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Splits "hotmail.comm" into ["hotmail", "comm"].
+     * Splits "yahoo.com.arr" into ["yahoo.com", "arr"].
+     */
+    private function splitAtLastDot(string $domain): array
+    {
+        $pos = strrpos($domain, '.');
+        if ($pos === false) {
+            return [$domain, ''];
+        }
+        return [substr($domain, 0, $pos), substr($domain, $pos + 1)];
+    }
+
+    private function logNewSuffix(string $providerName, string $tld): void
+    {
+        if ($this->newSuffixLog === null) {
+            return;
+        }
+
+        $firstLabel = explode('.', $providerName)[0];
+        $line = date('Y-m-d H:i:s') . "\t" . $firstLabel . "\t" . $tld . "\n";
+        @file_put_contents($this->newSuffixLog, $line, FILE_APPEND | LOCK_EX);
+    }
+}

--- a/src/Cleansers/Tld/TldCorrector.php
+++ b/src/Cleansers/Tld/TldCorrector.php
@@ -27,7 +27,7 @@ class TldCorrector
     // label (gov.XX, com.XX, mil.XX, edu.XX), XX is expected to be a country code,
     // not another generic TLD — otherwise "gov.go" resolves to "gov.io" instead of
     // "gov.co", and "com.con" resolves to "com.com" instead of "com.co".
-    const TWO_LEVEL_CONTEXT_LABELS = ['com', 'net', 'org', 'edu', 'gov', 'mil'];
+    const TWO_LEVEL_CONTEXT_LABELS = ['com', 'net', 'org', 'edu', 'gov', 'mil', 'gob'];
     const DEFAULT_COUNTRY_CODE_PARTNERS = ['co', 'ar', 'es', 'br', 'mx', 'cl', 'pe', 'uy'];
 
     /** @var IanaTldProvider */

--- a/src/Cleansers/Tld/TldCorrector.php
+++ b/src/Cleansers/Tld/TldCorrector.php
@@ -23,12 +23,18 @@ class TldCorrector
         'com', 'ar', 'es', 'net', 'org', 'br', 'io', 'co', 'lat', 'mx', 'cl', 'pe', 'uy', 'edu', 'gov',
     ];
 
-    private IanaTldProvider $iana;
-    private array $singleDomainProviders;
-    private array $multiRegionProviders;
-    private array $denylist;
-    private array $targetTlds;
-    private ?string $newSuffixLog;
+    /** @var IanaTldProvider */
+    private $iana;
+    /** @var array */
+    private $singleDomainProviders;
+    /** @var array */
+    private $multiRegionProviders;
+    /** @var array */
+    private $denylist;
+    /** @var array */
+    private $targetTlds;
+    /** @var string|null */
+    private $newSuffixLog;
 
     public function __construct(IanaTldProvider $iana, array $config = [])
     {
@@ -48,7 +54,7 @@ class TldCorrector
     {
         // Strip leading "@" for processing, restore it in the result.
         $domain = ltrim($emailDomain, '@');
-        [$name, $tld] = $this->splitAtLastDot($domain);
+        list($name, $tld) = $this->splitAtLastDot($domain);
 
         if ($tld === '') {
             return TldCorrectionResult::irrecoverable();
@@ -182,7 +188,7 @@ class TldCorrector
     {
         // Try longest matching prefix first to prefer "com.ar" over "com" for "comar".
         $candidates = $this->targetTlds;
-        usort($candidates, fn($a, $b) => strlen($b) - strlen($a));
+        usort($candidates, function ($a, $b) { return strlen($b) - strlen($a); });
 
         foreach ($candidates as $target) {
             if (strpos($tld, $target) === 0) {

--- a/src/Cleansers/Tld/TldCorrector.php
+++ b/src/Cleansers/Tld/TldCorrector.php
@@ -23,6 +23,13 @@ class TldCorrector
         'com', 'ar', 'es', 'net', 'org', 'br', 'io', 'co', 'lat', 'mx', 'cl', 'pe', 'uy', 'edu', 'gov',
     ];
 
+    // When the label right before the broken TLD is already a generic second-level
+    // label (gov.XX, com.XX, mil.XX, edu.XX), XX is expected to be a country code,
+    // not another generic TLD — otherwise "gov.go" resolves to "gov.io" instead of
+    // "gov.co", and "com.con" resolves to "com.com" instead of "com.co".
+    const TWO_LEVEL_CONTEXT_LABELS = ['com', 'net', 'org', 'edu', 'gov', 'mil'];
+    const DEFAULT_COUNTRY_CODE_PARTNERS = ['co', 'ar', 'es', 'br', 'mx', 'cl', 'pe', 'uy'];
+
     /** @var IanaTldProvider */
     private $iana;
     /** @var array */
@@ -33,6 +40,8 @@ class TldCorrector
     private $denylist;
     /** @var array */
     private $targetTlds;
+    /** @var array */
+    private $countryCodePartners;
     /** @var string|null */
     private $newSuffixLog;
 
@@ -43,6 +52,7 @@ class TldCorrector
         $this->multiRegionProviders  = $config['multi_region_providers']  ?? self::DEFAULT_MULTI_REGION_PROVIDERS;
         $this->denylist              = $config['denylist']                ?? self::DEFAULT_DENYLIST;
         $this->targetTlds            = $config['target_tlds']             ?? self::DEFAULT_TARGET_TLDS;
+        $this->countryCodePartners   = $config['country_code_partners']   ?? self::DEFAULT_COUNTRY_CODE_PARTNERS;
         $this->newSuffixLog          = $config['new_suffix_log']          ?? null;
     }
 
@@ -169,6 +179,17 @@ class TldCorrector
             $tld = $stripped;
         }
 
+        // Two-level context: "...com.XX" / "...gov.XX" / "...mil.XX" etc already
+        // has a generic label before the broken one, so XX is expected to be a
+        // country code — resolve against country candidates first.
+        $lastNameLabel = strpos($name, '.') !== false ? substr($name, strrpos($name, '.') + 1) : null;
+        if ($lastNameLabel !== null && in_array($lastNameLabel, self::TWO_LEVEL_CONTEXT_LABELS, true)) {
+            $countryMatch = $this->findByEditDistance($tld, 1, $this->countryCodePartners);
+            if ($countryMatch !== null) {
+                return $countryMatch;
+            }
+        }
+
         // Step 1: edit distance = 1 against target TLDs (ordered by frequency).
         $editMatch = $this->findByEditDistance($tld, 1);
         if ($editMatch !== null) {
@@ -179,9 +200,9 @@ class TldCorrector
         return $this->findByPrefix($name, $tld);
     }
 
-    private function findByEditDistance(string $tld, int $maxDistance): ?string
+    private function findByEditDistance(string $tld, int $maxDistance, ?array $candidates = null): ?string
     {
-        foreach ($this->targetTlds as $target) {
+        foreach ($candidates ?? $this->targetTlds as $target) {
             if (levenshtein($tld, $target) <= $maxDistance) {
                 return $target;
             }

--- a/src/Cleansers/Tld/TldCorrector.php
+++ b/src/Cleansers/Tld/TldCorrector.php
@@ -30,6 +30,13 @@ class TldCorrector
     const TWO_LEVEL_CONTEXT_LABELS = ['com', 'net', 'org', 'edu', 'gov', 'mil', 'gob'];
     const DEFAULT_COUNTRY_CODE_PARTNERS = ['co', 'ar', 'es', 'br', 'mx', 'cl', 'pe', 'uy'];
 
+    // Not real IANA TLDs, but real-world second-level conventions that show up
+    // truncated (missing the country suffix) in LatAm data — e.g. "mincetur.gob"
+    // instead of "mincetur.gob.pe". Edit distance would otherwise "fix" these to
+    // a real but wrong TLD ("gob" -> "gov", distance 1), corrupting a government
+    // domain. Never correct these away; treat them as already valid.
+    const DEFAULT_PROTECTED_TLDS = ['gob'];
+
     /** @var IanaTldProvider */
     private $iana;
     /** @var array */
@@ -42,6 +49,8 @@ class TldCorrector
     private $targetTlds;
     /** @var array */
     private $countryCodePartners;
+    /** @var array */
+    private $protectedTlds;
     /** @var string|null */
     private $newSuffixLog;
 
@@ -53,7 +62,13 @@ class TldCorrector
         $this->denylist              = $config['denylist']                ?? self::DEFAULT_DENYLIST;
         $this->targetTlds            = $config['target_tlds']             ?? self::DEFAULT_TARGET_TLDS;
         $this->countryCodePartners   = $config['country_code_partners']   ?? self::DEFAULT_COUNTRY_CODE_PARTNERS;
+        $this->protectedTlds         = $config['protected_tlds']          ?? self::DEFAULT_PROTECTED_TLDS;
         $this->newSuffixLog          = $config['new_suffix_log']          ?? null;
+    }
+
+    private function isRecognized(string $tld): bool
+    {
+        return $this->iana->isValid($tld) || in_array($tld, $this->protectedTlds, true);
     }
 
     /**
@@ -129,7 +144,7 @@ class TldCorrector
         // "hotmail.c" -> "co") never gets re-checked against the denylist and
         // a known provider ends up on a TLD it should never keep (hotmail.co).
         $wasCorrected = false;
-        if ($this->iana->isValid($tld)) {
+        if ($this->isRecognized($tld)) {
             $candidate = $tld;
         } else {
             $candidate = $this->correctInvalidTld($name, $tld);
@@ -158,7 +173,7 @@ class TldCorrector
 
     private function correctCustomDomain(string $name, string $tld): TldCorrectionResult
     {
-        if ($this->iana->isValid($tld)) {
+        if ($this->isRecognized($tld)) {
             return TldCorrectionResult::unchanged('@' . $name . '.' . $tld);
         }
 

--- a/src/Endpoints/Multiusers.php
+++ b/src/Endpoints/Multiusers.php
@@ -206,6 +206,10 @@ class Multiusers extends Endpoint
         if (!$isGmail) {
             if ($originalEmail !== $sanitizedEmail) {
                 $data['email'] = $sanitizedEmail;
+                if ($this->cleanser->email->wasTldCorrected()) {
+                    $data['tags'] = $this->cleanser->tags->addTag($data['tags'] ?? '', self::EMAIL_CLEANED);
+                    $data['tags'] = $this->cleanser->tags->removeTag($data['tags'] ?? '', self::EMAIL_REJECTED);
+                }
             }
             return $data;
         }


### PR DESCRIPTION
## Resumen

Mirror del PR de `woowup-php-client-v2`: agrega la misma corrección automática de sufijos TLD inválidos al cliente v1. La lógica es idéntica, bajo el namespace `WoowUp\Cleansers\Tld\`.

### Archivos nuevos

- `src/Cleansers/Tld/TldCorrectionResult.php` — value object con el resultado de la corrección
- `src/Cleansers/Tld/IanaTldProvider.php` — lista IANA con caché local y fallback hardcodeado
- `src/Cleansers/Tld/TldCorrector.php` — lógica de corrección idéntica a v2

### Archivos modificados

- `src/Cleansers/EmailCleanser.php` — integra `TldCorrector` opcional; expone `wasTldCorrected()`; corrige bug de armado del email no-Gmail
- `src/Cleansers/DataCleanser.php` — agrega `configureGlobalTldCorrector()` (static) y `setTldCorrector()` por instancia
- `src/Endpoints/Multiusers.php` — corrige bug: emails no-Gmail corregidos ahora reciben tag `email_cleaned` (antes se guardaban sin tag)

### Comportamiento

Idéntico al PR de v2. Ver tabla allá.

La corrección se activa solo si se inyecta un `TldCorrector` (opt-in). Sin él, el comportamiento es idéntico al anterior.
