### PR TITLE
fix(email): reject mail.mercadolibre.com as an invalid domain

### DIFF
--- a/src/Cleansers/EmailCleanser.php
+++ b/src/Cleansers/EmailCleanser.php
@@ -38,6 +38,9 @@ class EmailCleanser
 
     const INVALID_EMAIL = 'noemail@noemail.com';
 
+    // Marketplace-generated proxy addresses, not a real customer inbox.
+    const INVALID_DOMAINS = ['@mail.mercadolibre.com'];
+
     private $formatter;
     private $validators;
     private $emailUser;
@@ -77,6 +80,10 @@ class EmailCleanser
         $this->extractEmailParts($email);
 
         if (!$this->hasValidParts()) {
+            return false;
+        }
+
+        if ($this->isInvalidDomain()) {
             return false;
         }
 
@@ -196,6 +203,11 @@ class EmailCleanser
     private function isGmailDomain(): bool
     {
         return $this->emailDomain === '@gmail.com';
+    }
+
+    private function isInvalidDomain(): bool
+    {
+        return in_array(mb_strtolower($this->emailDomain), self::INVALID_DOMAINS, true);
     }
 
     private function sanitizeGmailEmail()

--- a/src/Endpoints/Users.php
+++ b/src/Endpoints/Users.php
@@ -204,6 +204,10 @@ class Users extends Endpoint
             $data['tags'] = $this->cleanser->tags->addTag($data['tags'] ?? '', self::EMAIL_REJECTED);
             $data['tags'] = $this->cleanser->tags->removeTag($data['tags'] ?? '', self::EMAIL_CLEANED);
             $data['tags'] = $this->cleanser->tags->removeTag($data['tags'] ?? '', self::EMAIL_VALIDATED);
+
+            $data['mailing_enabled'] = 'disabled';
+            $data['mailing_enabled_reason'] = 'other';
+
             return $data;
         }
 

--- a/src/Endpoints/Users.php
+++ b/src/Endpoints/Users.php
@@ -6,6 +6,7 @@ namespace WoowUp\Endpoints;
  */
 class Users extends Endpoint
 {
+    const INVALID_EMAIL = 'noemail@noemail.com';
     protected const TELEPHONE_CLEANED = 'telephone_cleaned';
     protected const TELEPHONE_REJECTED = 'telephone_rejected';
     protected const TELEPHONE_VALIDATED = 'telephone_validated';
@@ -200,13 +201,24 @@ class Users extends Endpoint
 
         $sanitizedEmail = $this->cleanser->email->sanitize($originalEmail);
 
-        if ($sanitizedEmail === false) {
+        if ($sanitizedEmail === false || $sanitizedEmail === self::INVALID_EMAIL) {
             $data['tags'] = $this->cleanser->tags->addTag($data['tags'] ?? '', self::EMAIL_REJECTED);
             $data['tags'] = $this->cleanser->tags->removeTag($data['tags'] ?? '', self::EMAIL_CLEANED);
             $data['tags'] = $this->cleanser->tags->removeTag($data['tags'] ?? '', self::EMAIL_VALIDATED);
 
             $data['mailing_enabled'] = 'disabled';
             $data['mailing_enabled_reason'] = 'other';
+
+            if ($sanitizedEmail === self::INVALID_EMAIL) {
+                $localPart =
+                    ($data['document']    ?? null) ?:
+                        ($data['service_uid'] ?? null) ?:
+                            ($data['telefono']    ?? null);
+
+                $data['email'] = $localPart
+                    ? $localPart . '@noemail.com'
+                    : $sanitizedEmail;
+            }
 
             return $data;
         }


### PR DESCRIPTION
## Problema
`mail.mercadolibre.com` es un dominio proxy que MercadoLibre genera para la mensajería de pedidos — no es una casilla real del cliente. `EmailCleanser::sanitize()` lo aceptaba como cualquier otro dominio.

Además, una vez que un email es rechazado por `Users::cleanEmail` (VTEX y otros conectores que usan `Users::create`/`update`), quedaba solo tageado `email_rejected` sin desactivar `mailing_enabled` — se le seguía intentando mandar mail a una casilla inválida. Y a diferencia de `Multiusers::cleanEmail`, `Users::cleanEmail` no manejaba el caso `EmailCleanser::INVALID_EMAIL` (usuario gmail cuya parte local se reduce a basura), dejando ese email roto sin reemplazar.

## Solución
- `EmailCleanser`: nueva constante `INVALID_DOMAINS` y chequeo `isInvalidDomain()` que rechaza (`return false`) cualquier email en el dominio exacto `mail.mercadolibre.com` (case-insensitive), igual que el chequeo existente de hash VTEX. No afecta `mercadolibre.com` ni otros subdominios. Mirror del mismo fix en `woowup-php-client-v2` (PR hermana).
- `Users::cleanEmail`: ahora desactiva `mailing_enabled`/`mailing_enabled_reason` para cualquier email rechazado (mercadolibre incluido), igual que ya hacía `Multiusers::cleanEmail`.
- `Users::cleanEmail`: agrega la constante `INVALID_EMAIL` y reemplaza el email por `{document|service_uid|telefono}@noemail.com` cuando `sanitize()` devuelve ese caso puntual — paridad con `Multiusers::cleanEmail`, que ya lo hacía.

No se toca `Multiusers::cleanEmail` (ya tenía este comportamiento) ni `Purchases::cleanEmail` (fuera de alcance).